### PR TITLE
Add ability to specify device to be used, Add basic kernel to run N iterations of a given hash, Change default to be large enough to work with a 24 word BIP39 seed

### DIFF
--- a/Library/opencl.py
+++ b/Library/opencl.py
@@ -578,7 +578,7 @@ class opencl_algos:
             self.max_out_bytes = bufStructs.specifySHA2(256, 128, saltlen, dklen)
             prg=self.opencl_ctx.compile(bufStructs, "sha256.cl", "pbkdf2.cl")
         elif type == "sha512":
-            self.max_out_bytes = bufStructs.specifySHA2(512, 128, saltlen, dklen)
+            self.max_out_bytes = bufStructs.specifySHA2(512, 256, saltlen, dklen)
             prg=self.opencl_ctx.compile(bufStructs, "sha512.cl", "pbkdf2.cl")
         else:
             assert ("Error on hash type, unknown !!!")

--- a/Library/opencl.py
+++ b/Library/opencl.py
@@ -39,7 +39,7 @@ class opencl_interface:
     inv_memory_density=1
     # Initialiser for the key properties
     #   pbkdf related initialisation removed, will reappear somewhere else
-    def __init__(self, platformNum, debug=0, write_combined_file=False, maxWorkgroupSize=60000, inv_memory_density=1, N_value=15):
+    def __init__(self, platformNum, debug=0, write_combined_file=False, maxWorkgroupSize=60000, inv_memory_density=1, N_value=15, openclDevice = 0):
         printif(debug,"Using Platform %d:" % platformNum)
         devices = cl.get_platforms()[platformNum].get_devices()
         self.platform_number=platformNum
@@ -51,7 +51,7 @@ class opencl_interface:
         self.sworkgroupsize = self.determineWorkgroupsize(N_value)
         self.inv_memory_density=inv_memory_density
         self.ctx = cl.Context(devices)
-        self.queue = cl.CommandQueue(self.ctx)
+        self.queue = cl.CommandQueue(self.ctx, devices[openclDevice])
         self.debug=debug
 
         for device in devices:
@@ -377,10 +377,10 @@ class opencl_interface:
 
 
 class opencl_algos:
-    def __init__(self, platform, debug, write_combined_file, inv_memory_density=1):
+    def __init__(self, platform, debug, write_combined_file, inv_memory_density=1, openclDevice = 0):
         if debug==False:
             debug=0
-        self.opencl_ctx= opencl_interface(platform, debug, write_combined_file)
+        self.opencl_ctx= opencl_interface(platform, debug, write_combined_file, openclDevice = openclDevice)
         self.platform_number=platform
         self.inv_memory_density=inv_memory_density
 

--- a/Library/worker/generic/hash_iterations.cl
+++ b/Library/worker/generic/hash_iterations.cl
@@ -1,0 +1,22 @@
+// Extremely basic (but useful) script to perform a certain number of hashing iterations when used with a pre-existing
+// hasing library which is called via hash_main. (Useful for some cryptocurrency wallets which use custom key stretching)
+//
+// Generally speaking, this this function will take a hash (and maybe salted) password as the input, with this initial
+// hash happening in the calling application. This means that the input and output will always be the same size and that
+// we don't need to worry about padding, etc...
+//
+// Originally created for BTCRecover by Stephen Rothery, available at https://github.com/3rdIteration/btcrecover
+__kernel void hash_iterations(__global inbuf *inbuffer, __global outbuf *outbuffer, __private unsigned int iters, __private unsigned int hash_size)
+{
+    unsigned int idx = get_global_id(0);
+
+    // Iterate through and has the input as many times as required
+    for (unsigned int j = 0; j < iters; j++){
+        hash_main(inbuffer, outbuffer);
+
+        // Copy the output from the hash back in to the input...
+        for (unsigned int i = 0; i < hash_size; i++){
+            inbuffer[idx].buffer[i] = outbuffer[idx].buffer[i];
+        }
+    }
+}

--- a/test.py
+++ b/test.py
@@ -70,7 +70,6 @@ def hmac_test(passwordlist, salt, hashClass, clResult):
         print(clResult[0])
         print(correct_res[0])
 
-
 def md5_hmac_test(opencl_algo, passwordlist, salt):
     print("Testing hmac using md5.cl")
     ctx=opencl_algo.cl_md5_init("pbkdf2.cl")
@@ -164,6 +163,73 @@ def scrypt_test(scrypt_opencl_algos, passwords, N_value=15, r_value=3, p_value=1
                 print(clResult[i])
                 print(correct_res[i])
 
+def test_iterations(passwordlist, hashClass, iters, clResult):
+    hashlib_passwords = []
+    for password in passwordlist:
+        for i in range(iters):
+            password = hashClass(password).digest()
+        hashlib_passwords.append(password)
+
+    if clResult == hashlib_passwords:
+        print("Ok")
+    else:
+        print("Failed !")
+        for i in range(len(passwordlist)):
+            if clResult[i] == hashlib_passwords[i]:
+                print("#{} succeeded".format(i))
+            else:
+                print(i)
+                print(clResult[i])
+                print(hashlib_passwords[i])
+
+def hash_iterations_md5_test(opencl_algo, passwordlist, iters):
+    print()
+    print("Testing md5 " + str(iters) + " rounds")
+    ctx = opencl_algo.cl_hash_iterations_init("md5")
+
+    for i in range(len(passwordlist)):
+        passwordlist[i] = hashlib.md5(passwordlist[i]).digest()
+
+    clresult = opencl_algo.cl_hash_iterations(ctx, passwordlist, iters, 4)
+
+    test_iterations(passwordlist,hashlib.md5,iters,clresult)
+
+def hash_iterations_sha1_test(opencl_algo, passwordlist, iters):
+    print()
+    print("Testing sha1 " + str(iters) + " rounds")
+    ctx = opencl_algo.cl_hash_iterations_init("sha1")
+
+    for i in range(len(passwordlist)):
+        passwordlist[i] = hashlib.sha1(passwordlist[i]).digest()
+
+    clresult = opencl_algo.cl_hash_iterations(ctx, passwordlist, iters, 8)
+
+    test_iterations(passwordlist, hashlib.sha1, iters, clresult)
+
+def hash_iterations_sha256_test(opencl_algo, passwordlist, iters):
+    print()
+    print("Testing sha256 " + str(iters) + " rounds")
+    ctx = opencl_algo.cl_hash_iterations_init("sha256")
+
+    for i in range(len(passwordlist)):
+        passwordlist[i] = hashlib.sha256(passwordlist[i]).digest()
+
+    clresult = opencl_algo.cl_hash_iterations(ctx, passwordlist, iters, 8)
+
+    test_iterations(passwordlist, hashlib.sha256, iters, clresult)
+
+def hash_iterations_sha512_test(opencl_algo, passwordlist, iters):
+    print()
+    print("Testing sha512 " + str(iters) + " rounds")
+    ctx = opencl_algo.cl_hash_iterations_init("sha512")
+
+    for i in range(len(passwordlist)):
+        passwordlist[i] = hashlib.sha512(passwordlist[i]).digest()
+
+    clresult = opencl_algo.cl_hash_iterations(ctx, passwordlist, iters, 8)
+
+    test_iterations(passwordlist, hashlib.sha512, iters, clresult)
+
 # ===========================================================================================
 
 def main(argv):
@@ -201,8 +267,13 @@ def main(argv):
         pbkdf2_hmac_sha1_test(opencl_algos, passwordlist, salt, 1000, 50)
         pbkdf2_hmac_sha256_test(opencl_algos, passwordlist, salt, 1000, 50)
         pbkdf2_hmac_sha512_test(opencl_algos, passwordlist, salt, 1000, 50)
-    
+
         scrypt_test(opencl_algos,passwordlist,15,3,1,0x20,salt)
+
+        hash_iterations_md5_test(opencl_algos, passwordlist, 10000)
+        hash_iterations_sha1_test(opencl_algos, passwordlist, 10000)
+        hash_iterations_sha256_test(opencl_algos, passwordlist, 10000)
+        hash_iterations_sha512_test(opencl_algos, passwordlist, 10000)
 
     print("Tests have finished.")
 


### PR DESCRIPTION
Just a few tweaks that I made as part of BTCRecover (https://github.com/3rdIteration/btcrecover)

They are very simple but greatly improved the utility of this library in the context of how it is used as part of BTCRecover.